### PR TITLE
#70 issue resolved

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -3,6 +3,7 @@
 
 * {
   box-sizing: border-box;
+  user-select: none;
 }
 
 :root {

--- a/assets/main.html
+++ b/assets/main.html
@@ -17,7 +17,7 @@
     <title>Let's Play the Game !!!</title>
   </head>
 
-  <body>
+  <body oncontextmenu="return false;">
     <div id="preloader" class="loader">
       <img src="images/preloader.gif" alt="">
     </div>


### PR DESCRIPTION
# Fixes Issue🛠️

<!-- Example: Closes #31 -->

Closes #70

# Description👨‍💻 

Selecting the text and images or right-clicking anyway on the game screen is so annoying and creates disturbances to the user.
<!--Please include a summary of the change and which issue is fixed.List any dependencies that are required for this change.-->

# Type of change📄

<!--Please delete options that are not relevant.-->

- [] Bug fix (No right-click menu appears)
- [] Bug fix (No text can be selected)
- 
# How this has been tested✅

You cannot select any text or other components on this site and can't get the right-click menu anywhere.
You can check out this <a href="https://suman-tewary.github.io/Click-The-Edible-Game/">link</a>.
<!--Please describe the tests that you ran to verify your changes.-->

# Checklist✅ 

- [] My code follows the style guidelines of this project
- [] I am an Open Source Contributor

# Screenshots/GIF📷
Before:::
![select text 2](https://user-images.githubusercontent.com/43510749/220602716-29a25a31-5251-462b-9289-3884d5be713e.jpg)
![select text](https://user-images.githubusercontent.com/43510749/220602730-a9f81ed1-cd9b-476b-b453-a86f68ecd1bb.jpg)
