### PR TITLE
Update in Scrollbar to match dark-colour-aesthetic for dark mode

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -888,12 +888,12 @@ h1 {
 }
 
 .dark-theme *::-webkit-scrollbar-track {
-    background: linear-gradient(#212121, #3a3a3a, #212121);
+    background: linear-gradient(#3d3d3d, #383737, #464646);
 }
 
 .dark-theme *::-webkit-scrollbar-thumb {
-    background: linear-gradient(#1f1f1f, #3a3a3a, #161616);
-    border: 2.5px solid rgb(19, 19, 19);
+    background: linear-gradient(#1f1f1f, #1f1f1f, #161616);
+    border: 2.5px solid rgb(21, 21, 21);
 }
 
 .dark-theme #instruction-btn {

--- a/assets/main.css
+++ b/assets/main.css
@@ -887,6 +887,15 @@ h1 {
     color: #b7b7b7 ;
 }
 
+.dark-theme *::-webkit-scrollbar-track {
+    background: linear-gradient(#212121, #3a3a3a, #212121);
+}
+
+.dark-theme *::-webkit-scrollbar-thumb {
+    background: linear-gradient(#1f1f1f, #3a3a3a, #161616);
+    border: 2.5px solid rgb(19, 19, 19);
+}
+
 .dark-theme #instruction-btn {
     border: none ;
     background-color: #044bc7 ;

--- a/assets/main.css
+++ b/assets/main.css
@@ -888,12 +888,12 @@ h1 {
 }
 
 .dark-theme *::-webkit-scrollbar-track {
-    background: linear-gradient(#3d3d3d, #383737, #464646);
+    background: linear-gradient(#373737, #3c3c3c, #373737);
 }
 
 .dark-theme *::-webkit-scrollbar-thumb {
-    background: linear-gradient(#1f1f1f, #1f1f1f, #161616);
-    border: 2.5px solid rgb(21, 21, 21);
+    background: linear-gradient(#121212, #1c1c1c, #121212);
+    border: 1.5px solid whitesmoke;
 }
 
 .dark-theme #instruction-btn {


### PR DESCRIPTION
# Fixes Issue🛠️

<!-- Example: Closes #31 -->

Closes #143 

# Description👨‍💻 

Here, I am updating the Scrollbar to match the dark-coloured-aesthetic when the dark mode is turned on by the user. This will enhance its visibility and improve the overall user experience.

- [x]  Updation in UI to maintain the dark-theme in scrollbar when using dark mode
- [x]  Enhance user experience of the website


# Type of change📄

<!--Please delete options that are not relevant.-->

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How this has been tested✅

I have tested this enhancement on my local device to ensure an improved theme aesthetic and better user experience. Any more suggestions are welcome.

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added demonstration in the form of GIF/video file
- [x] I am an Open Source Contributor

# Screenshots/GIF📷

<img width="1440" alt="Screenshot 2023-10-29 at 12 24 14 PM" src="https://github.com/Rakesh9100/Click-The-Edible-Game/assets/112189682/13b9f5ee-d465-4f11-aeee-f792afbc6097">


<img width="1440" alt="Screenshot 2023-10-29 at 12 17 29 PM" src="https://github.com/Rakesh9100/Click-The-Edible-Game/assets/112189682/35d2b534-16f0-4a67-a0bf-ba27ce146a7e">


