### PR TITLE
Fixed: Instruction box appears above the time-frame selection box

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -201,7 +201,7 @@ h3 {
     background-color: #eaf9d9;
     border-radius: 0.5em;
     position: absolute;
-    z-index: 9;
+    z-index: 8;
     padding: 1rem;
     font-family: 'Times New Roman', Times, serif;
     font-weight: bold;


### PR DESCRIPTION
# Fixes Issue🛠️

Closes #147 

# Description👨‍💻 

The instruction box now appears above the time-frame selcetion box when the player wants to see the instructions while they are in the time-frame selection window.

# Type of change📄

- [x] Bug fix (non-breaking change which fixes an issue)

# How this has been tested✅

Tested on my local machine, desired changes are being properly reflected.

# Checklist✅ 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added demonstration in the form of GIF/video file
- [x] I am an Open Source Contributor

# Screenshots/GIF📷
![bug-fixed_time_vs_instructions](https://github.com/Rakesh9100/Click-The-Edible-Game/assets/86418216/41414fdc-1b7d-4cd4-8efb-0453487e54e1)

